### PR TITLE
Ime input conflict

### DIFF
--- a/src/app/pages/WorkDetailPage.tsx
+++ b/src/app/pages/WorkDetailPage.tsx
@@ -20,6 +20,35 @@ function filterTagsByQuery(tags: Tag[], query: string): Tag[] {
   );
 }
 
+function WorkTagNoteInput({
+  note,
+  onSave,
+}: {
+  note: string;
+  onSave: (nextNote: string) => Promise<void>;
+}) {
+  const [draft, setDraft] = useState(note);
+
+  useEffect(() => {
+    setDraft(note);
+  }, [note]);
+
+  const handleBlur = () => {
+    if (draft === note) return;
+    void onSave(draft);
+  };
+
+  return (
+    <input
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={handleBlur}
+      placeholder="メモ"
+      className="w-[220px]"
+    />
+  );
+}
+
 export function WorkDetailPage() {
   const { uuid } = useParams<"uuid">();
   const { workRepository, tagRepository } = useDependencies();
@@ -97,8 +126,13 @@ export function WorkDetailPage() {
   const handleNoteChange = async (tagId: string, note: string) => {
     if (!uuid) return;
     try {
-      await updateWorkTagNote(uuid, tagId, note, workRepository);
-      reload();
+      const updatedWork = await updateWorkTagNote(
+        uuid,
+        tagId,
+        note,
+        workRepository,
+      );
+      setWork(updatedWork);
     } catch (err) {
       alert((err as Error).message);
     }
@@ -129,12 +163,10 @@ export function WorkDetailPage() {
                 className="mb-3 flex items-center gap-3"
               >
                 <Link to={`/tags/${wt.tag.uuid}`}>{wt.tag.name}</Link>
-                <input
-                  value={wt.note}
-                  onChange={(e) => handleNoteChange(wt.tag.uuid, e.target.value)}
-                  onBlur={(e) => handleNoteChange(wt.tag.uuid, e.target.value)}
-                  placeholder="メモ"
-                  className="w-[220px]"
+                <WorkTagNoteInput
+                  note={wt.note}
+                  onSave={(nextNote) =>
+                    handleNoteChange(wt.tag.uuid, nextNote)}
                 />
                 <button type="button" onClick={() => handleUnlink(wt.tag.uuid)}>
                   外す


### PR DESCRIPTION
Refactor memo input in `WorkDetailPage` to prevent IME conflicts.

The previous implementation saved and reloaded on every `onChange` event, causing IME input to break due to re-rendering during composition. This change introduces a local state for the input, saves only on `onBlur` when the value has changed, and updates the work object directly instead of a full `reload()`.

---
Linear Issue: [MAR-7](https://linear.app/marco3jp/issue/MAR-7/メモのところがimeとかち合って入力できない)

<p><a href="https://cursor.com/agents/bc-c3424cf5-6664-43be-9911-afe151d45972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3424cf5-6664-43be-9911-afe151d45972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state refactor that changes when tag memo updates are persisted (on blur instead of per-keystroke) and avoids a full reload; main risk is subtle UX/state sync issues if saves fail or notes update concurrently.
> 
> **Overview**
> Refactors the tag memo input on `WorkDetailPage` to avoid IME/composition breakage by introducing `WorkTagNoteInput` with local draft state and persisting changes only on `onBlur` when the value actually changed.
> 
> Updates the memo-save flow to use the `updateWorkTagNote` return value to update `work` via `setWork(...)` instead of calling `reload()`, reducing re-renders while typing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4ce4122319108ec4de0c8111a08a56489a94e3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->