### PR TITLE
Add AGENTS.md for Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+**Sparkling Journey** はクライアントサイドのみで動作する SPA（React + TypeScript + Vite）。データは `localStorage` に保存され、バックエンドやデータベースは不要。
+
+### Services
+
+| Service | Command | Notes |
+|---|---|---|
+| Dev server | `npm run dev` | Vite dev server with HMR. `--host 0.0.0.0` で外部アクセス可 |
+| Lint | `npm run lint` | ESLint。既存コードに pre-existing な lint エラーあり（既知） |
+| Test | `npx vitest run` | Vitest 2.x と Vite 8.x-beta の互換性問題により全テスト失敗（`__vite_ssr_exportName__` エラー）。これは既知の pre-existing issue |
+| Build | `npm run build` | `tsc -b && vite build`。正常に動作する |
+
+### Caveats
+
+- Node.js 24 が必要（CI の `deploy.yml` に準拠）。nvm で `nvm use 24` を使用。
+- `vite.config.ts` の `base` が `/sparkling-journey/` に設定されているため、dev server の URL は `http://localhost:5173/sparkling-journey/`。
+- Vitest のテストは Vite 8 beta との非互換で失敗する。`package.json` の `overrides` で Vite 8 を強制しているが、Vitest 2.x はこれに対応していない。テストフレームワークのアップグレードが必要。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cursor Cloud の開発環境セットアップ用に `AGENTS.md` を追加。

### Changes
- `AGENTS.md` を新規作成し、Cursor Cloud エージェント向けの開発環境情報を記載
  - サービス一覧（dev server / lint / test / build）とそれぞれのコマンド
  - Node.js 24 の要件
  - `vite.config.ts` の `base` パス設定に関する注意事項
  - Vitest 2.x と Vite 8.x-beta の既知の互換性問題についての注記

### Environment Setup Verified
- ✅ `npm ci` — 依存関係のインストール
- ✅ `npm run build` — TypeScript コンパイル + Vite ビルド成功
- ✅ `npm run dev` — 開発サーバー起動・ブラウザでの動作確認済み
- ⚠️ `npm run lint` — 既存コードに pre-existing lint エラーあり（本PRの変更とは無関係）
- ⚠️ `npx vitest run` — Vitest 2.x / Vite 8.x-beta 間の既知の互換性問題で全テスト失敗（本PRの変更とは無関係）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07412010-aa09-4987-9c09-4d453ddbe0db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07412010-aa09-4987-9c09-4d453ddbe0db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

